### PR TITLE
Notice of Copyright Violation

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,7 @@
 Copyright (c) 2009-2015 Bitcoin Developers
 Copyright (c) 2014-2015 Dash Developers
-Copyright (c) 2018 Prx Developers
+Copyright (c) 2015-2018 PIVX Developers
+Copyright (c) 2018-2019 Prx Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is an official notice of Copyright violation against the PIVX developers in which this project has been forked from. The MIT copyright license, and subsequent copyright headers in source files have been modified to explicitly exclude the PIVX developers from all copyrights.

You are hereby notified of an intention to pursue further action if this issue is not acknowledged and formally addressed with a resolution timeframe commitment wherein. Failure to acknowledge and correct the violation will result in a formal DMCA takedown notice filed with GitHub Proper after no less than five business days from the date of this notice.

Explicit acknowledgement and referencing progress to maintain compliance MUST be noted in this issue's comments or referred to in any subsequent pull requests to this repository